### PR TITLE
build: add path deps for siblings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "3"
-members = ["ark-serde-compat", "circom-types", "groth16", "groth16-material", "groth16-sol"]
+members = [
+  "ark-serde-compat",
+  "circom-types",
+  "groth16",
+  "groth16-material",
+  "groth16-sol"
+]
 
 [workspace.package]
 edition = "2024"
@@ -10,6 +16,7 @@ repository = "https://github.com/TaceoLabs/circom-helpers"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+alloy-primitives = "1"
 ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "0.5" }
 ark-bls12-381 = "0.5"
 ark-bn254 = { version = "0.5" }
@@ -18,22 +25,20 @@ ark-ff = { version = "0.5", default-features = false }
 ark-groth16 = { version = "0.5", default-features = false }
 ark-poly = { version = "0.5", default-features = false }
 ark-relations = { version = "0.5", default-features = false }
-ark-serde-compat = { package = "taceo-ark-serde-compat", path = "ark-serde-compat", version = "0.5.0", default-features = false }
 ark-serialize = { version = "0.5", default-features = false }
+ark-snark = "0.5"
 ark-std = "0.5"
 byteorder = "1.5"
 ciborium = "0.2.2"
-circom-types = { package = "taceo-circom-types", path = "circom-types", version = "0.2.4" }
 circom-witness-rs = "0.2.3"
 clap = { version = "4.4.8", features = ["derive"] }
 eyre = "0.6"
-groth16 = { package = "taceo-groth16", path = "groth16", version = "0.1" }
 hex = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
+postcard = "1"
 rand = "0.8"
 rayon = "1.8"
-postcard = "1"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls"
 ] }

--- a/circom-types/Cargo.toml
+++ b/circom-types/Cargo.toml
@@ -31,13 +31,12 @@ ark-ff = { workspace = true }
 ark-groth16 = { workspace = true, optional = true }
 ark-poly = { workspace = true }
 ark-relations = { workspace = true, optional = true }
-ark-serde-compat = { workspace = true }
+ark-serde-compat = { package = "taceo-ark-serde-compat", path = "../ark-serde-compat", version = "0.5.0", default-features=false }
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 byteorder = { workspace = true }
 clap = { workspace = true, features = ["env"], optional = true }
 eyre = { workspace = true, optional = true }
-num-traits = { workspace = true }
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -47,6 +46,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"], optional = t
 
 [dev-dependencies]
 num-bigint = { workspace = true }
+num-traits = { workspace = true }
 
 [features]
 default = ["bn254", "full-groth16", "parallel"]

--- a/deny.toml
+++ b/deny.toml
@@ -76,7 +76,8 @@ ignore = [
     { id = "RUSTSEC-2023-0089", reason = "atomic-polyfill, dep of ark-circom, is unmaintained, only used in tests." },
     { id = "RUSTSEC-2025-0057", reason = "fxhash, dep of ark-circom, is unmaintained, only used in tests." },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error, dep of ark-circom, is unmaintained, only used in tests." },
-    { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained, only used in tests."}
+    { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained, only used in tests."},
+    { id = "RUSTSEC-2026-0097", reason = "can't upgrade due to transative deps. Doesn't affect us because we don't enable the log feature" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/groth16-material/Cargo.toml
+++ b/groth16-material/Cargo.toml
@@ -12,35 +12,41 @@ keywords = ["circom", "groth16", "zero-knowledge", "zk"]
 
 [package.metadata.cargo-all-features]
 skip_feature_sets = [
-  ["circom", "noir"],
   ["reqwest", "reqwest-blocking"],
 ]
 max_combination_size = 2
 
 [dependencies]
 ark-bn254 = { workspace = true }
-ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
-ark-relations = { workspace = true }
 ark-serialize = { workspace = true, optional = true }
-circom-types = { workspace = true, features = ["bn254", "groth16", "zkey"] }
+circom-types = { package = "taceo-circom-types", path = "../circom-types", version = "0.2.4", features = [
+  "bn254",
+  "groth16",
+  "zkey"
+], default-features = false }
 circom-witness-rs = { workspace = true, optional = true }
 eyre = { workspace = true }
-groth16 = { workspace = true }
-hex = { workspace = true }
-rand = { workspace = true }
+groth16 = { package = "taceo-groth16", path = "../groth16", version = "0.1.2" }
+hex = { workspace = true, optional = true }
 postcard = { workspace = true, optional = true }
+rand = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ruint = { workspace = true, optional = true }
-sha2 = { workspace = true }
+sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [features]
 default = ["circom"]
-circom = ["dep:ark-serialize", "dep:circom-witness-rs", "dep:postcard", "dep:ruint"]
-full = ["circom", "noir"]
-noir = []
+circom = [
+  "dep:ark-serialize",
+  "dep:circom-witness-rs",
+  "dep:hex",
+  "dep:postcard",
+  "dep:ruint",
+  "dep:sha2"
+]
+full = ["circom"]
 reqwest = ["dep:reqwest"]
 reqwest-blocking = ["reqwest/blocking"]

--- a/groth16-sol/Cargo.toml
+++ b/groth16-sol/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "taceo-groth16-sol"
 version = "0.3.0"
-description = "Generation of Solidity verifiers for Groth16 zkSNARKs, based on the Groth16 verifier template from gnark."
-keywords = ["zkSNARKs", "Groth16", "Solidity", "verifier"]
-readme = "./README.md"
 edition.workspace = true
 rust-version.workspace = true
+description = "Generation of Solidity verifiers for Groth16 zkSNARKs, based on the Groth16 verifier template from gnark."
+readme = "./README.md"
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
+keywords = ["Groth16", "Solidity", "verifier", "zkSNARKs"]
 exclude = ["/data"]
 
 [[bin]]
@@ -17,22 +17,22 @@ path = "src/bin/groth16-sol-utils.rs"
 required-features = ["bin"]
 
 [dependencies]
-alloy-primitives = "1"
+alloy-primitives.workspace = true
 ark-bn254.workspace = true
 ark-ec.workspace = true
 ark-ff.workspace = true
 ark-groth16.workspace = true
 askama = { version = "0.15.4", optional = true }
-circom-types = { workspace = true, optional = true }
+circom-types = { package = "taceo-circom-types", path = "../circom-types", version = "0.2.4", optional = true, default-features = false, features=["groth16", "proof", "public-input","verification-key"] }
 clap = { workspace = true, features = ["derive"], optional = true }
 eyre.workspace = true
 ruint = { workspace = true, features = ["ark-ff-05"] }
 serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
-circom-types.workspace = true
-serde_json.workspace = true
+circom-types = { package = "taceo-circom-types", path = "../circom-types", version = "0.2.4" }
 rand.workspace = true
+serde_json.workspace = true
 
 [features]
 default = ["template"]

--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -22,12 +22,11 @@ ark-groth16 = { workspace = true, features = ["parallel"] }
 ark-poly.workspace = true
 ark-relations.workspace = true
 eyre.workspace = true
-num-traits.workspace = true
 rayon.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 ark-bn254.workspace = true
-ark-snark = "0.5.0"
+ark-snark.workspace = true
 ark-std.workspace = true
 criterion = "0.8"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build/manifest-only changes that mainly affect dependency resolution and feature wiring; low runtime risk but may cause compile/CI issues if paths, versions, or feature flags are misaligned.
> 
> **Overview**
> Standardizes dependency wiring across the workspace by moving common crates (e.g. `alloy-primitives`, `ark-snark`, `postcard`) into `[workspace.dependencies]` and switching several crates to explicit sibling `path` dependencies with pinned versions for `taceo-*` crates.
> 
> Tweaks crate feature/dependency configuration: `groth16-material` narrows `full` to `circom`, makes `hex`/`sha2` optional and part of the `circom` feature, and removes unused deps; `circom-types` moves `num-traits` to dev-deps; `groth16-sol` aligns metadata order and uses workspace `alloy-primitives` plus explicit `circom-types` feature selection. Updates `deny.toml` to ignore an additional RustSec advisory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79797e5a221854d87c675a617cb60a2ca2820b22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->