### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly updates for each Dependabot ecosystem mapped from the detected languages on the default branch.

Detected languages: Just,Rust,Solidity

- Weekly updates for `github-actions`
- Weekly updates for `cargo`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects Dependabot update scheduling/behavior in GitHub, not runtime code.
> 
> **Overview**
> Adds a `cooldown` policy to `.github/dependabot.yml` so weekly `github-actions` and `cargo` update checks wait **3 days** by default before proposing subsequent updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a881513b02d503f8a4224f0f7d4d0c004f3e18f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->