### PR TITLE
chore: add minimal permission set to GitHub workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   cargo-deny:

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -8,6 +8,9 @@ on:
       - v*
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   # incremental builds are slower and don't make much sense in ci
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -8,6 +8,9 @@ on:
       - v*
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   # incremental builds are slower and don't make much sense in ci
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary

- Add explicit `contents: read` permissions to `rust_test.yml` and `rust_lint.yml` workflows that were missing permission declarations
- Narrow `audit.yml` from `read-all` to `contents: read` for least-privilege security
- `rolling.yml` and `release-plz.yml` already had appropriate minimal permissions

This follows GitHub's security best practice of using the principle of least privilege for workflow permissions.

## Test plan

- [ ] Verify CI workflows still pass with the new permission restrictions

Slack thread: https://taceo-labs.slack.com/archives/C0AT60XB2HJ/p1777550069241229

https://claude.ai/code/session_01S4riaZu2TxRJMWMQ15sZdG

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4riaZu2TxRJMWMQ15sZdG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission tightening; main risk is CI breakage if any job implicitly relied on broader GitHub token scopes.
> 
> **Overview**
> Applies *least-privilege* GitHub Actions permissions across Rust CI workflows.
> 
> `audit.yml` is narrowed from `read-all` to `contents: read`, and `rust_lint.yml`/`rust_test.yml` now explicitly declare `permissions: contents: read` so the jobs run with read-only repository access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2fdb2b02839fc2244e120eb0cdbbbd272e2a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->